### PR TITLE
fix/assets + indexの文言修正

### DIFF
--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -8,7 +8,7 @@
 <div id="falling-leaves" class="falling-layer" aria-hidden="true"></div>
 <div class="hero">
   <div class="hero-title">PKに挑戦！</div>
-  <div class="hero-sub">左・中・右の三択で読み合い。君は何連ゴールできる？</div>
+  <div class="hero-sub">左・中・右の３択で読み合い。キミは何連ゴールできる？</div>
 </div>
 
 <p class="kick-prompt">どこに蹴る？</p>
@@ -33,5 +33,5 @@
 
 <div class="pk-mini-stats">
   <span>ゴール率 <%= @stats[:rate] %>%<%= @stats[:streak] %></span>
-  <%= link_to "▶ 戦績一覧を見る", stats_games_path, class: "pk-mini-stats__link" %>
+  <%= link_to "▶ 戦績一覧へ", stats_games_path, class: "pk-mini-stats__link" %>
 </div>


### PR DESCRIPTION
## 概要
デプロイ時にエラー発生（以下、Koyebのdeployログ）
```
`[fb5f105f-fa09-9517-afb6-81e9877bcc3e]   
[fb5f105f-fa09-9517-afb6-81e9877bcc3e] app/views/games/index.html.erb:16
I, [2026-03-23T14:37:07.107367 #1]  INFO -- : [91fafb98-4d94-91df-a1a4-a77986d3cf81] Started GET "/" for 60.102.177.209 at 2026-03-23 14:37:07 +0000
I, [2026-03-23T14:37:07.108304 #1]  INFO -- : [91fafb98-4d94-91df-a1a4-a77986d3cf81] Processing by GamesController#index as HTML
I, [2026-03-23T14:37:07.110282 #1]  INFO -- : [91fafb98-4d94-91df-a1a4-a77986d3cf81]   Rendered layout layouts/application.html.erb (Duration: 0.8ms | Allocations: 349)
I, [2026-03-23T14:37:07.110554 #1]  INFO -- : [91fafb98-4d94-91df-a1a4-a77986d3cf81] Completed 500 Internal Server Error in 2ms (ActiveRecord: 0.0ms | Allocations: 808)
E, [2026-03-23T14:37:07.111624 #1] ERROR -- : [91fafb98-4d94-91df-a1a4-a77986d3cf81]   
[91fafb98-4d94-91df-a1a4-a77986d3cf81] ActionView::Template::Error (The asset "pk_goal_2.png" is not present in the asset pipeline.
):
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     13: 
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     14: <p class="kick-prompt">どこに蹴る？</p>
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     15: <div class="pk-field">
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     16:   <%= image_tag "pk_goal_2.png", class: "goal", alt: "" %>
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     17: 
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     18:   <%= image_tag "keeper_normal.png", class: "keeper #{@keeper_choice}", alt: "" %>
[91fafb98-4d94-91df-a1a4-a77986d3cf81]     19: 
[91fafb98-4d94-91df-a1a4-a77986d3cf81]   
[91fafb98-4d94-91df-a1a4-a77986d3cf81] app/views/games/index.html.erb:16
Instance is stopping.
- Gracefully stopping, waiting for requests to finish
Exiting
Instance stopped.
Instance created. Preparing to start...
```

github上の```assets```にある`pk_goal_2.png`が`pk_goal_2.PNG`であったため、修正。