### PR TITLE
Stimulus controller の登録方法が混在

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,6 +1,5 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-import DojoDoorController from "./fusuma_controller"
-application.register("fusuma", DojoDoorController)
+
 eagerLoadControllersFrom("controllers", application)


### PR DESCRIPTION
## 概要

本番環境で fusuma アニメーションが動作しない問題を修正しました。
原因は Stimulus controller の登録方法が「手動登録」と「eager load」で混在していたことによるもので、本番環境で `fusuma_controller` の読み込みパス解決が崩れていました。
登録方法を `eagerLoadControllersFrom` に一本化することで解消しました。

## 変更内容

* Stimulus controller の登録方法を整理
* `application.register()` による手動登録を削除
* `eagerLoadControllersFrom("controllers", application)` による自動ロードに統一

## 変更ファイル

* `app/javascript/controllers/index.js`

## 動作確認

* 本番環境で fusuma アニメーションが正常に表示されることを確認
* セッション初回アクセス時のみアニメーションが再生されることを確認
* ページリロード時はアニメーションがスキップされることを確認

## 関連Issue

* なし
